### PR TITLE
Refactor if statement AST structure

### DIFF
--- a/codegen/src/ir_builder.rs
+++ b/codegen/src/ir_builder.rs
@@ -134,7 +134,7 @@ impl<'i> FunctionIrBuilder<'i> {
                 FoundReturn::No
             }
             Statement::NestedBlock { .. } => todo!(),
-            Statement::If { .. } => todo!("if statement codegen not implemented yet"),
+            Statement::If(_) => todo!("if statement codegen not implemented yet"),
         }
     }
 

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -70,11 +70,7 @@ pub enum Statement<'a, Phase: CompilationPhase> {
     NestedBlock {
         block: &'a Block<'a, Phase>,
     },
-    If {
-        condition: &'a Expression<'a, Phase>,
-        then_block: &'a Block<'a, Phase>,
-        else_block: Option<&'a IfElseBlock<'a, Phase>>,
-    },
+    If(&'a IfStatement<'a, Phase>),
 }
 
 #[derive(Debug, PartialEq)]
@@ -272,16 +268,8 @@ impl Display for Statement<'_, PhaseParsed<'_>> {
             Statement::NestedBlock { block } => {
                 write!(f, "{}", block)
             }
-            Statement::If {
-                condition,
-                then_block,
-                else_block,
-            } => {
-                write!(f, "if {} {}", condition, then_block)?;
-                if let Some(else_block) = else_block {
-                    write!(f, " else {}", else_block)?;
-                }
-                Ok(())
+            Statement::If(if_statement) => {
+                write!(f, "{}", if_statement)
             }
         }
     }

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -78,9 +78,16 @@ pub enum Statement<'a, Phase: CompilationPhase> {
 }
 
 #[derive(Debug, PartialEq)]
+pub struct IfStatement<'a, Phase: CompilationPhase> {
+    pub condition: &'a Expression<'a, Phase>,
+    pub then_block: &'a Block<'a, Phase>,
+    pub else_block: Option<&'a IfElseBlock<'a, Phase>>,
+}
+
+#[derive(Debug, PartialEq)]
 pub enum IfElseBlock<'a, Phase: CompilationPhase> {
     Block(&'a Block<'a, Phase>),
-    If(&'a Statement<'a, Phase>),
+    If(&'a IfStatement<'a, Phase>),
 }
 
 #[derive(Debug, PartialEq)]
@@ -277,6 +284,16 @@ impl Display for Statement<'_, PhaseParsed<'_>> {
                 Ok(())
             }
         }
+    }
+}
+
+impl Display for IfStatement<'_, PhaseParsed<'_>> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "if {} {}", self.condition, self.then_block)?;
+        if let Some(else_block) = &self.else_block {
+            write!(f, " else {}", else_block)?;
+        }
+        Ok(())
     }
 }
 

--- a/parser/src/parsed_ast.rs
+++ b/parser/src/parsed_ast.rs
@@ -253,11 +253,12 @@ impl ParsedAstAllocator {
         'b: 's,
         'e: 's,
     {
-        self.allocator.alloc(Statement::If {
+        let if_statement = self.allocator.alloc(IfStatement {
             condition,
             then_block,
             else_block,
-        })
+        });
+        self.allocator.alloc(Statement::If(if_statement))
     }
 
     pub fn if_else_block<'s, 'b>(

--- a/parser/src/parsed_ast.rs
+++ b/parser/src/parsed_ast.rs
@@ -1,8 +1,8 @@
 use crate::symbols::StringId;
 use crate::{
     AstAllocator, BinaryOperator, Block, BlockId, CompilationPhase, Expression, FunctionArgument,
-    FunctionDeclaration, FunctionSignature, IfElseBlock, LetInitializer, LiteralValue, Module,
-    Statement, UnaryOperator, intern_string,
+    FunctionDeclaration, FunctionSignature, IfElseBlock, IfStatement, LetInitializer, LiteralValue,
+    Module, Statement, UnaryOperator, intern_string,
 };
 use bumpalo::collections::Vec as BumpVec;
 use std::collections::HashMap;
@@ -270,13 +270,22 @@ impl ParsedAstAllocator {
         self.allocator.alloc(IfElseBlock::Block(block))
     }
 
-    pub fn if_else_if<'s, 'i>(
+    pub fn if_else_if<'s, 'c, 't, 'e>(
         &'s self,
-        if_stmt: &'i Statement<'i, PhaseParsed<'s>>,
+        condition: &'c Expression<'c, PhaseParsed<'s>>,
+        then_block: &'t Block<'t, PhaseParsed<'s>>,
+        else_block: Option<&'e IfElseBlock<'e, PhaseParsed<'s>>>,
     ) -> &'s IfElseBlock<'s, PhaseParsed<'s>>
     where
-        'i: 's,
+        'c: 's,
+        't: 's,
+        'e: 's,
     {
-        self.allocator.alloc(IfElseBlock::If(if_stmt))
+        let if_statement = self.allocator.alloc(IfStatement {
+            condition,
+            then_block,
+            else_block,
+        });
+        self.allocator.alloc(IfElseBlock::If(if_statement))
     }
 }

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -1,6 +1,6 @@
 use crate::ast::{
-    BinaryOperator, Block, Expression, FunctionArgument, FunctionDeclaration, LetInitializer,
-    Module, Statement, UnaryOperator,
+    BinaryOperator, Block, Expression, FunctionArgument, FunctionDeclaration, IfElseBlock,
+    LetInitializer, Module, Statement, UnaryOperator,
 };
 use crate::grammar::{Grammar, Rule};
 use crate::parsed_ast::{FunctionSignaturesByName, ParsedAstAllocator, PhaseParsed};
@@ -132,6 +132,27 @@ fn parse_let_statement<'a>(
     ast_allocator.statement_let(initializers)
 }
 
+fn parse_if_else_recursive<'a>(
+    ast_allocator: &'a ParsedAstAllocator,
+    rule: Pair<'_, Rule>,
+) -> &'a IfElseBlock<'a, PhaseParsed<'a>> {
+    let mut inner = rule.into_inner();
+    let condition = parse_expression(ast_allocator, inner.next().expect("if condition"));
+    let then_block = parse_block(ast_allocator, inner.next().expect("then block"));
+
+    let else_block = if let Some(else_part) = inner.next() {
+        match else_part.as_rule() {
+            Rule::block => Some(ast_allocator.if_else_block(parse_block(ast_allocator, else_part))),
+            Rule::ifStatement => Some(parse_if_else_recursive(ast_allocator, else_part)),
+            _ => unreachable!("unexpected else part"),
+        }
+    } else {
+        None
+    };
+
+    ast_allocator.if_else_if(condition, then_block, else_block)
+}
+
 fn parse_if_statement<'a>(
     ast_allocator: &'a ParsedAstAllocator,
     rule: Pair<'_, Rule>,
@@ -144,9 +165,7 @@ fn parse_if_statement<'a>(
     let else_block = if let Some(else_part) = inner.next() {
         match else_part.as_rule() {
             Rule::block => Some(ast_allocator.if_else_block(parse_block(ast_allocator, else_part))),
-            Rule::ifStatement => {
-                Some(ast_allocator.if_else_if(parse_if_statement(ast_allocator, else_part)))
-            }
+            Rule::ifStatement => Some(parse_if_else_recursive(ast_allocator, else_part)),
             _ => unreachable!("unexpected else part"),
         }
     } else {

--- a/semantic_analysis/src/ast_typed.rs
+++ b/semantic_analysis/src/ast_typed.rs
@@ -1,9 +1,9 @@
 use crate::types::Type;
 use bumpalo::collections::Vec as BumpVec;
 use parser::{
-    resolve_string_id, AstAllocator, BinaryOperator, Block, BlockId, CompilationPhase,
-    Expression, FunctionDeclaration, FunctionSignature, IfElseBlock, LiteralValue, Module, Statement,
-    StringId,
+    AstAllocator, BinaryOperator, Block, BlockId, CompilationPhase, Expression,
+    FunctionDeclaration, FunctionSignature, IfElseBlock, IfStatement, LiteralValue, Module,
+    Statement, StringId, resolve_string_id,
 };
 use std::borrow::BorrowMut;
 use std::cell::RefCell;
@@ -307,24 +307,15 @@ fn fmt_if_else_block_with_context(
         IfElseBlock::Block(block) => fmt_with_context(f, block, context.indented()),
         IfElseBlock::If(if_statement) => {
             // For else if, we don't want extra indentation since it's part of the same if chain
-            if let Statement::If {
-                condition,
-                then_block,
-                else_block,
-            } = if_statement
-            {
-                write!(f, "  if ")?;
-                fmt_with_symbol_table(f, condition, context.symbol_table)?;
-                write!(f, " ")?;
-                fmt_with_context(f, then_block, context.indented())?;
-                if let Some(nested_else_block) = else_block {
-                    write!(f, "{}  else ", context.indent)?;
-                    fmt_if_else_block_with_context(f, nested_else_block, context)?;
-                }
-                Ok(())
-            } else {
-                panic!("Expected If statement in IfElseBlock::If");
+            write!(f, "  if ")?;
+            fmt_with_symbol_table(f, if_statement.condition, context.symbol_table)?;
+            write!(f, " ")?;
+            fmt_with_context(f, if_statement.then_block, context.indented())?;
+            if let Some(nested_else_block) = if_statement.else_block {
+                write!(f, "{}  else ", context.indent)?;
+                fmt_if_else_block_with_context(f, nested_else_block, context)?;
             }
+            Ok(())
         }
     }
 }

--- a/semantic_analysis/src/ast_typed.rs
+++ b/semantic_analysis/src/ast_typed.rs
@@ -280,18 +280,30 @@ fn fmt_statement_with_context(
             write!(f, "{}  ", context.indent)?;
             fmt_with_context(f, block, context.indented())
         }
-        Statement::If(if_statement) => {
-            write!(f, "{}  if ", context.indent)?;
-            fmt_with_symbol_table(f, if_statement.condition, context.symbol_table)?;
-            write!(f, " ")?;
-            fmt_with_context(f, if_statement.then_block, context.indented())?;
-            if let Some(else_block) = if_statement.else_block {
-                write!(f, "{}  else ", context.indent)?;
-                fmt_if_else_block_with_context(f, else_block, context)?;
-            }
-            Ok(())
-        }
+        Statement::If(if_statement) => fmt_if_statement_with_context(
+            f,
+            if_statement,
+            context,
+            &format!("{}  ", context.indent),
+        ),
     }
+}
+
+fn fmt_if_statement_with_context(
+    f: &mut Formatter<'_>,
+    if_statement: &IfStatement<PhaseTypeResolved>,
+    context: &DisplayTypedAstContext,
+    if_prefix: &str,
+) -> std::fmt::Result {
+    write!(f, "{}if ", if_prefix)?;
+    fmt_with_symbol_table(f, if_statement.condition, context.symbol_table)?;
+    write!(f, " ")?;
+    fmt_with_context(f, if_statement.then_block, context.indented())?;
+    if let Some(else_block) = if_statement.else_block {
+        write!(f, "{}  else ", context.indent)?;
+        fmt_if_else_block_with_context(f, else_block, context)?;
+    }
+    Ok(())
 }
 
 fn fmt_if_else_block_with_context(
@@ -303,15 +315,7 @@ fn fmt_if_else_block_with_context(
         IfElseBlock::Block(block) => fmt_with_context(f, block, context.indented()),
         IfElseBlock::If(if_statement) => {
             // For else if, we don't want extra indentation since it's part of the same if chain
-            write!(f, "  if ")?;
-            fmt_with_symbol_table(f, if_statement.condition, context.symbol_table)?;
-            write!(f, " ")?;
-            fmt_with_context(f, if_statement.then_block, context.indented())?;
-            if let Some(nested_else_block) = if_statement.else_block {
-                write!(f, "{}  else ", context.indent)?;
-                fmt_if_else_block_with_context(f, nested_else_block, context)?;
-            }
-            Ok(())
+            fmt_if_statement_with_context(f, if_statement, context, "  ")
         }
     }
 }

--- a/semantic_analysis/src/ast_typed.rs
+++ b/semantic_analysis/src/ast_typed.rs
@@ -280,16 +280,12 @@ fn fmt_statement_with_context(
             write!(f, "{}  ", context.indent)?;
             fmt_with_context(f, block, context.indented())
         }
-        Statement::If {
-            condition,
-            then_block,
-            else_block,
-        } => {
+        Statement::If(if_statement) => {
             write!(f, "{}  if ", context.indent)?;
-            fmt_with_symbol_table(f, condition, context.symbol_table)?;
+            fmt_with_symbol_table(f, if_statement.condition, context.symbol_table)?;
             write!(f, " ")?;
-            fmt_with_context(f, then_block, context.indented())?;
-            if let Some(else_block) = else_block {
+            fmt_with_context(f, if_statement.then_block, context.indented())?;
+            if let Some(else_block) = if_statement.else_block {
                 write!(f, "{}  else ", context.indent)?;
                 fmt_if_else_block_with_context(f, else_block, context)?;
             }

--- a/semantic_analysis/src/phase_type_resolver.rs
+++ b/semantic_analysis/src/phase_type_resolver.rs
@@ -4,8 +4,8 @@ use crate::{ArgumentIndex, PhaseTypeResolved, SymbolKind, SymbolTable, Type, res
 use bumpalo::collections::Vec as BumpVec;
 use parser::{
     AstAllocator, BinaryOperator, Block, Expression, FunctionDeclaration, FunctionSignature,
-    FunctionSignaturesByName, IfElseBlock, LetInitializer, Module, Statement, StringId,
-    UnaryOperator, resolve_string_id,
+    FunctionSignaturesByName, IfElseBlock, IfStatement, LetInitializer, Module, Statement,
+    StringId, UnaryOperator, resolve_string_id,
 };
 use std::cmp::Ordering;
 use std::collections::HashMap;
@@ -357,16 +357,45 @@ impl<'a> TypeResolver {
                 Ok(allocator.alloc(IfElseBlock::Block(typed_block)))
             }
             IfElseBlock::If(if_statement) => {
-                let mut statements = allocator.new_bump_vec_with_capacity(1);
-                Self::analyze_statement(allocator, if_statement, &mut statements, symbol_table)?;
+                // Type check the condition - it must be a boolean expression
+                let analyzed_condition =
+                    Self::analyze_expression(allocator, if_statement.condition, symbol_table)?;
+                let condition_type = resolved_type(analyzed_condition);
 
-                // The statement should be an If statement
-                if let Some(Statement::If { .. }) = statements.first() {
-                    Ok(allocator.alloc(IfElseBlock::If(statements[0])))
-                } else {
-                    // This shouldn't happen if the parser is correct
-                    panic!("Expected If statement in IfElseBlock::If");
+                match condition_type {
+                    Some(Type::Bool) => {
+                        // Condition is valid, continue with blocks
+                    }
+                    Some(other_type) => {
+                        return Err(SemanticAnalysisError::IfConditionMustBeBool {
+                            actual_type: other_type.to_string(),
+                        });
+                    }
+                    None => {
+                        return Err(SemanticAnalysisError::IfConditionMustBeBool {
+                            actual_type: "void".to_string(),
+                        });
+                    }
                 }
+
+                let analyzed_then_block =
+                    Self::analyze_block(allocator, if_statement.then_block, symbol_table)?;
+                let analyzed_else_block = if let Some(else_block) = if_statement.else_block {
+                    Some(Self::analyze_if_else_block(
+                        allocator,
+                        else_block,
+                        symbol_table,
+                    )?)
+                } else {
+                    None
+                };
+
+                let analyzed_if_statement = allocator.alloc(IfStatement {
+                    condition: analyzed_condition,
+                    then_block: analyzed_then_block,
+                    else_block: analyzed_else_block,
+                });
+                Ok(allocator.alloc(IfElseBlock::If(analyzed_if_statement)))
             }
         }
     }


### PR DESCRIPTION
## Summary
- Refactor if statement AST structure from inline fields to dedicated types
- Improve code organization and maintainability
- Update all phases (parsing, semantic analysis, display) to use new structure

## Implementation Details
- **AST Refactoring**: Changed from `Statement::If { condition, then_block, else_block }` to `Statement::If(&IfStatement)`
- **New Types**: Introduced dedicated `IfStatement` and `IfElseBlock` types for better structure
- **Parser Updates**: Refactored parsing logic to reduce duplication and improve clarity
- **Semantic Analysis**: Updated type checking to work with new AST structure
- **Display Formatting**: Improved formatting logic for typed AST display

## Key Changes
- `Statement::If` now uses a dedicated `IfStatement` struct
- `IfElseBlock::If` contains `&IfStatement` instead of `&Statement`
- Cleaner separation of concerns between parsing and AST construction
- More maintainable code structure for future if statement enhancements

## Status
This PR builds on the `ifs` branch which contains the foundational if statement implementation. The refactoring improves the code structure while maintaining all existing functionality.

🤖 Generated with [Claude Code](https://claude.ai/code)